### PR TITLE
Wallet account mapping

### DIFF
--- a/cli/commands/rewards/generatemerkle.ts
+++ b/cli/commands/rewards/generatemerkle.ts
@@ -6,6 +6,7 @@ import { EventLog } from 'web3-core'
 import { flags } from '@oclif/command'
 import { parseBalanceMap } from '../../../src/parse-balance-map'
 import { BaseCommand } from '../../base'
+import { eventTypes } from '../../utils/events'
 import {
   AttestationIssuers,
   calculateRewards,
@@ -96,12 +97,12 @@ export default class CalculateRewards extends BaseCommand {
 
     attestationEvents.forEach(event => {
       progressBar.increment()
-      if (event.event == 'AttestationCompleted') {
+      if (event.event === eventTypes.AttestationCompleted) {
         processAttestationCompletion(state, trackIssuers, event)
-      } else if (event.event == "AccountWalletAddressSet") {
+      } else if (event.event === eventTypes.AccountWalletAddressSet) {
         processAccountWalletAddressSet(state.walletAssociations, event)
       } else {
-        this.error(`Uknown event:\n${event}`) 
+        this.error(unknownEventError(event)) 
       }
     })
 
@@ -116,10 +117,10 @@ export default class CalculateRewards extends BaseCommand {
       } else if (event.blockNumber > state.blockNumberToFinishTracking) {
         break
       }
-      if (event.event = 'Transfer') {
+      if (event.event === eventTypes.Transfer) {
         processTransfer(state, event)
       } else {
-        this.error(`Uknown event:\n${event}`)
+        this.error(unknownEventError(event))
       }
     }
 
@@ -141,8 +142,12 @@ export default class CalculateRewards extends BaseCommand {
   }
 }
 
-export function eventsJSONToArray(eventFiles: string[]): EventLog[] {
+function eventsJSONToArray(eventFiles: string[]): EventLog[] {
   return eventFiles
     .map((eventFile: string) => JSON.parse(fs.readFileSync(eventFile, 'utf8')))
     .reduce((acc, el) => acc.concat(el))
+}
+
+function unknownEventError(event: EventLog): string {
+  return `Unknown event:\n${event}`
 }

--- a/cli/utils/calculate-rewards.ts
+++ b/cli/utils/calculate-rewards.ts
@@ -107,10 +107,7 @@ export function processAccountWalletAddressSet(walletAssociations: WalletAssocia
 export function accountIsVerified(state: RewardsCalculationState, account: string): boolean {
   let walletAssociations = state.walletAssociations
   let associatedAddresses = walletAssociations[account] ? walletAssociations[account] : [account]
-  for (let i in associatedAddresses) {
-    if (state.attestationCompletions[associatedAddresses[i]] >= 3) return true
-  }
-  return false
+  return associatedAddresses.some(address => state.attestationCompletions[address] >= 3)
 }
 
 export function processTransfer(state: RewardsCalculationState, event: EventLog) {
@@ -126,9 +123,8 @@ function updateBalanceByBlock(
   account: string,
   blockNumber: number
 ) {
-  // @ts-ignore
   if (accountIsVerified(state, account)) {
-    let balancesByBlock = state.balancesByBlock[account]
+    const balancesByBlock = state.balancesByBlock[account]
     if (balancesByBlock && balancesByBlock.balances.length > 0) {
       balancesByBlock.balances.push(state.balances[account])
       balancesByBlock.blocks.push(blockNumber)

--- a/cli/utils/events.ts
+++ b/cli/utils/events.ts
@@ -1,5 +1,11 @@
 import { EventLog } from 'web3-core'
 
+export enum eventTypes  {
+  Transfer                = 'Transfer',
+  AttestationCompleted    = 'AttestationCompleted',
+  AccountWalletAddressSet = 'AccountWalletAddressSet'
+}
+
 export async function getPastEvents(
   progressBar: any,
   contract: any,


### PR DESCRIPTION
Accounts for the fact that a wallet may be associated with more than one account. Mapping looks like this:
```
{
   wallet => [account1],
   wallet => [account2, account3, account4],
   wallet => [account3]
}
```
In most situations a wallet with multiple accounts has only one of those accounts verified. So if a wallet is linked to at least 1 verified account, it will qualify for rewards. This PR does not take any action in regards to an account with many wallets. In the above example you can see `account3` is listed twice. As the code stands, if this happens, no action is taken. Right now this case does not appear to occur. **Update** was notified that someone would really have to go out of their way to have the reverse mapping above --^ So we will not monitor this case for now.
